### PR TITLE
update pickup and carry

### DIFF
--- a/Week 90 Jam/Assets/Prefabs/Mutant.prefab
+++ b/Week 90 Jam/Assets/Prefabs/Mutant.prefab
@@ -1,6 +1,6 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &8049209781393194243
+--- !u!1 &7999935458769179891
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -8,48 +8,48 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 8049209781393194240}
-  - component: {fileID: 8049209781393194271}
-  - component: {fileID: 8049209781393194270}
-  - component: {fileID: 8049209781393194241}
-  - component: {fileID: 4812963384632963069}
-  - component: {fileID: 1134047745}
+  - component: {fileID: 2160388756931451725}
+  - component: {fileID: 1563727335130967408}
+  - component: {fileID: 3765721150483602777}
+  - component: {fileID: 5129841220981524946}
+  - component: {fileID: 8850289327886303697}
+  - component: {fileID: 8222171157067523285}
   m_Layer: 0
-  m_Name: Cube
+  m_Name: PickUpCarryZone
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &8049209781393194240
+--- !u!4 &2160388756931451725
 Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8049209781393194243}
+  m_GameObject: {fileID: 7999935458769179891}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -1.94}
+  m_LocalPosition: {x: 0, y: 0, z: -1.412}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 8049209781490706150}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!33 &8049209781393194271
+--- !u!33 &1563727335130967408
 MeshFilter:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8049209781393194243}
+  m_GameObject: {fileID: 7999935458769179891}
   m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
---- !u!23 &8049209781393194270
+--- !u!23 &3765721150483602777
 MeshRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8049209781393194243}
+  m_GameObject: {fileID: 7999935458769179891}
   m_Enabled: 0
   m_CastShadows: 1
   m_ReceiveShadows: 1
@@ -80,26 +80,13 @@ MeshRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
---- !u!65 &8049209781393194241
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8049209781393194243}
-  m_Material: {fileID: 0}
-  m_IsTrigger: 1
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
---- !u!114 &4812963384632963069
+--- !u!114 &5129841220981524946
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8049209781393194243}
+  m_GameObject: {fileID: 7999935458769179891}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f598a3a394075c9408c1a98f48589191, type: 3}
@@ -109,23 +96,36 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 512
   CollidingGameObjects: []
---- !u!114 &1134047745
+--- !u!136 &8850289327886303697
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7999935458769179891}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  m_Radius: 0.9016372
+  m_Height: 2.813003
+  m_Direction: 0
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &8222171157067523285
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8049209781393194243}
+  m_GameObject: {fileID: 7999935458769179891}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 021292a80c81a408db04a79f252738f6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  pickupableLayer:
-    serializedVersion: 2
-    m_Bits: 256
   potentialHoldObject: {fileID: 0}
   objectHeld: {fileID: 0}
+  originalPos: {x: 0, y: 0, z: 0}
+  isUsingGravity: 0
 --- !u!1 &8049209781490706156
 GameObject:
   m_ObjectHideFlags: 0
@@ -160,7 +160,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 6114877865140927259}
-  - {fileID: 8049209781393194240}
+  - {fileID: 2160388756931451725}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -252,7 +252,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   playerNumber: 1
-  CollisionCube: {fileID: 8049209781393194243}
+  controllerNumber: 0
+  CollisionCube: {fileID: 0}
   StationMask:
     serializedVersion: 2
     m_Bits: 512

--- a/Week 90 Jam/Assets/Scripts/CarryObject.cs
+++ b/Week 90 Jam/Assets/Scripts/CarryObject.cs
@@ -2,16 +2,10 @@
 
 public class CarryObject : MonoBehaviour
 {
-    public LayerMask pickupableLayer;
     public GameObject potentialHoldObject;
     public GameObject objectHeld;
-
-
-    /*
-     * 
-     *      PICKUP UPDATE SCRIPT MOVED TO MUTANT CONTROLLER SCRIPT FOR PICKUP INPUT BINDING. (RAZ)
-     * 
-     */
+    public Vector3 originalPos;
+    public bool isUsingGravity;
 
     private void OnTriggerEnter(Collider other)
     {
@@ -25,13 +19,18 @@ public class CarryObject : MonoBehaviour
 
     public void PickUpObject(GameObject gObj)
     {
-        gObj.transform.parent = transform.parent.transform;
-        gObj.transform.position += new Vector3(0, 0.61f, 0);
+        originalPos = gObj.transform.position;
+        gObj.transform.parent = transform;
+        gObj.transform.localPosition = Vector3.zero;
     }
     
     public void DropUpObject(GameObject gObj)
     {
         gObj.transform.parent = null;
-        gObj.transform.position -= new Vector3(0, 0.61f, 0);
+        
+        if (isUsingGravity) return;
+        Vector3 newPos = gObj.transform.position;
+        newPos.y = originalPos.y;
+        gObj.transform.position = newPos;
     }
 }


### PR DESCRIPTION
https://trello.com/c/I2AnVnPz/39-update-player-picking-up-objects-so-they-snap-to-a-held-position-and-increase-the-angle-at-which-you-can-pick-up

## Done
- Use of a capsule collider to get a better range of pick-up (didn't wanna do raycasting)
- pickup centers with the mutant (picks it up a little, centers it, stores the axisY incase it needs to be set down on the same level and there is no gravity... hoping there will be and we can just disable/bool this setting.
- drop off places it back on the same Y axis it came from... unless we want gravity on something then we need to disable that boolean on/before drop.

## Task:
[x] - Improve the pick-up radius (hoping the collider works for this)
[x] - Check the updated collision so we don't destroy objects when we collide (Raz did already)
[x ] - Improve dropping items, seems they get picked back up quick, might reverse the KeyUp/KeyDown needs, or addition of a bool (Raz did already)

## Related to:
- https://trello.com/c/UZ0yYiKx/36-physically-pick-up-items
- https://trello.com/c/F1SSFBqb/12-pickup-item-system
